### PR TITLE
Fix out of bound crash

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -219,7 +219,7 @@ func readStreamInfo(r io.Reader) (*StreamInfo, error) {
 		return nil, err
 	}
 	if len(csum) != md5.Size {
-		panic("Bad MD5 checksum size")
+		return nil, errors.New("Bad MD5 checksum size")
 	}
 	copy(info.MD5[:], csum)
 

--- a/decode.go
+++ b/decode.go
@@ -737,7 +737,7 @@ func decodeLPCSubFrame(br *bit.Reader, sampleSize uint, blkSize int, predO int) 
 	}
 	shift := int(signExtend(s, 5))
 	if shift < 0 {
-		panic("What does a negative shift mean‽")
+		return nil, errors.New("Invalid negative shift")
 	}
 
 	coeffs, err := readInts(br, predO, uint(prec))

--- a/decode.go
+++ b/decode.go
@@ -670,7 +670,7 @@ func readSubFrameHeader(br *bit.Reader) (kind subFrameKind, order int, err error
 		kind = subFrameLPC
 
 	default:
-		panic("Impossible!")
+		return 0, 0, errors.New("Invalid subframe type")
 	}
 
 	n := 0

--- a/decode.go
+++ b/decode.go
@@ -303,7 +303,7 @@ func (d *Decoder) Next() ([]byte, error) {
 	}
 
 	fixChannels(data, h.channelAssignment)
-	return interleave(data, d.BitsPerSample), nil
+	return interleave(data, d.BitsPerSample)
 }
 
 func readSubFrame(br *bit.Reader, h *frameHeader, ch int) ([]int32, error) {
@@ -378,7 +378,7 @@ func fixChannels(data [][]int32, assign channelAssignment) {
 	}
 }
 
-func interleave(chs [][]int32, bps int) []byte {
+func interleave(chs [][]int32, bps int) ([]byte, error) {
 	nSamples := len(chs[0])
 
 	switch bps {
@@ -391,7 +391,7 @@ func interleave(chs [][]int32, bps int) []byte {
 				i++
 			}
 		}
-		return data
+		return data, nil
 
 	case 16:
 		data := make([]byte, 2*nSamples*len(chs))
@@ -404,7 +404,7 @@ func interleave(chs [][]int32, bps int) []byte {
 				i += 2
 			}
 		}
-		return data
+		return data, nil
 
 	case 24:
 		data := make([]byte, 3*nSamples*len(chs))
@@ -418,11 +418,10 @@ func interleave(chs [][]int32, bps int) []byte {
 				i += 3
 			}
 		}
-		return data
+		return data, nil
 
-	default:
-		panic("Unsupported bits per sample")
 	}
+	return nil, errors.New("Unsupported bits per sample")
 }
 
 type frameHeader struct {

--- a/decode.go
+++ b/decode.go
@@ -803,7 +803,7 @@ func decodeResiduals(br *bit.Reader, blkSize int, predO int) ([]int32, error) {
 		if err != nil {
 			return nil, err
 		} else if (bits == 4 && M == 0xF) || (bits == 5 && M == 0x1F) {
-			panic("Unsupported, unencoded residuals")
+			return nil, errors.New("Unsupported, unencoded residuals")
 		}
 
 		n := 0

--- a/decode.go
+++ b/decode.go
@@ -349,7 +349,7 @@ func readSubFrame(br *bit.Reader, h *frameHeader, ch int) ([]int32, error) {
 		}
 
 	default:
-		panic("Unsupported frame kind")
+		return nil, errors.New("Unsupported frame kind")
 	}
 
 	return data, nil


### PR DESCRIPTION
Hello,

I am interested in the go-fuzz tool and run it on random libraries. Here is your turn. It triggered one out of bounds panic in vorbis comment decoding and various hard coded panics in other parts of the code. I believe panicking on user inputs in third party libraries is not really good style so made some others return an error instead.

I have not written additional tests because I do not have too much time to spend on this, but I can provide binary inputs triggering the issues if you want to,